### PR TITLE
Remove ObjectManager and Fix DataTargetRepository DI

### DIFF
--- a/Classes/DatabaseTrait.php
+++ b/Classes/DatabaseTrait.php
@@ -44,18 +44,17 @@ trait DatabaseTrait
      * @var Connection
      * @deprecated
      */
-    protected $database;
+    protected ?Connection $database = null;
 
     /**
      * Constructor
      * @param ConnectionPool|null $connectionPool
      * @param DatabaseConnectionService|null $connectionService
      */
-    public function __construct(protected ConnectionPool $connectionPool, protected DatabaseConnectionService $connectionService)
-    {
-        if (!$this->database instanceof Connection) {
-            $this->database = $GLOBALS['TYPO3_DB'];
-        }
+    public function __construct(
+        protected ConnectionPool $connectionPool,
+        protected DatabaseConnectionService $connectionService
+    ) {
     }
 
     /**
@@ -65,7 +64,7 @@ trait DatabaseTrait
      */
     public function getDataBase(): Connection
     {
-        return $this->database;
+        return $this->database ??= $this->connectionPool->getConnectionByName('Default');
     }
 
     public function getDatabaseConnectionService(): DatabaseConnectionService

--- a/Classes/Domain/Model/TaskResult.php
+++ b/Classes/Domain/Model/TaskResult.php
@@ -30,7 +30,7 @@ use CPSIT\T3importExport\Messaging\MessageContainer;
 use CPSIT\T3importExport\Messaging\MessageContainerTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class TaskResult implements \Iterator
+class TaskResult implements \Iterator, \Countable
 {
     use MessageContainerTrait;
 
@@ -38,22 +38,22 @@ class TaskResult implements \Iterator
     /**
      * @var int
      */
-    protected $position = 0;
+    protected int $position = 0;
 
     /**
      * @var array
      */
-    protected $list = [];
+    protected array $list = [];
 
     /**
      * @var int
      */
-    protected $size = 0;
+    protected int $size = 0;
 
     /**
      * @var null|mixed
      */
-    protected $info;
+    protected mixed $info;
 
     /**
      * TaskResult constructor.
@@ -71,7 +71,7 @@ class TaskResult implements \Iterator
     /**
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->list[$this->position];
     }
@@ -79,7 +79,7 @@ class TaskResult implements \Iterator
     /**
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -87,7 +87,7 @@ class TaskResult implements \Iterator
     /**
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -95,7 +95,7 @@ class TaskResult implements \Iterator
     /**
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->list[$this->position]);
     }
@@ -103,16 +103,15 @@ class TaskResult implements \Iterator
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->size;
     }
 
     /**
      * @return void
-     * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
@@ -121,7 +120,7 @@ class TaskResult implements \Iterator
      * @param array $elements
      * @return void
      */
-    public function setElements(array $elements)
+    public function setElements(array $elements): void
     {
         $this->list = $elements;
         $this->size = count($elements);
@@ -132,7 +131,7 @@ class TaskResult implements \Iterator
      * @param $newElement
      * @return void
      */
-    public function add($newElement)
+    public function add(mixed $newElement): void
     {
         $this->list[] = $newElement;
         ++$this->size;
@@ -142,7 +141,7 @@ class TaskResult implements \Iterator
      * @param $element
      * @return bool
      */
-    public function removeElement($element)
+    public function removeElement(mixed $element): bool
     {
         $key = array_search($element, $this->list);
         if ($key !== false) {
@@ -155,7 +154,7 @@ class TaskResult implements \Iterator
      * @param $index
      * @return bool
      */
-    public function removeIndex($index)
+    public function removeIndex(mixed $index): bool
     {
         if ($this->size > $index) {
             unset($this->list[$index]);
@@ -174,7 +173,7 @@ class TaskResult implements \Iterator
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->list;
     }
@@ -183,12 +182,12 @@ class TaskResult implements \Iterator
      * @param $mixed
      * @return void
      */
-    public function setInfo($mixed)
+    public function setInfo(mixed $mixed): void
     {
         $this->info = $mixed;
     }
 
-    public function getInfo()
+    public function getInfo(): mixed
     {
         return $this->info;
     }
@@ -199,7 +198,8 @@ class TaskResult implements \Iterator
      *
      * @param array $messages
      */
-    public function addMessages(array $messages) {
+    public function addMessages(array $messages): void
+    {
         $this->messageContainer->addMessages($messages);
     }
 }

--- a/Classes/Persistence/DataTargetRepository.php
+++ b/Classes/Persistence/DataTargetRepository.php
@@ -62,9 +62,8 @@ class DataTargetRepository implements DataTargetInterface
      * @param RepositoryInterface|null $repository
      * @param PersistenceManagerInterface|null $persistenceManager
      */
-    public function __construct(string $targetClass, RepositoryInterface $repository = null, PersistenceManagerInterface $persistenceManager = null)
+    public function __construct(RepositoryInterface $repository = null, PersistenceManagerInterface $persistenceManager = null)
     {
-        $this->targetClass = $targetClass;
         $this->repository = $repository;
         if ($persistenceManager === null) {
             $persistenceManager = GeneralUtility::makeInstance(PersistenceManagerInterface::class);
@@ -129,6 +128,15 @@ class DataTargetRepository implements DataTargetInterface
     public function persistAll($result = null, array $configuration = null)
     {
         $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @param string $targetClass
+     * @return void
+     */
+    public function setTargetClass(string $targetClass)
+    {
+        $this->targetClass = $targetClass;
     }
 
     /**

--- a/Classes/Persistence/DataTargetRepository.php
+++ b/Classes/Persistence/DataTargetRepository.php
@@ -5,7 +5,6 @@ namespace CPSIT\T3importExport\Persistence;
 use CPSIT\T3importExport\MissingClassException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\RepositoryInterface;
@@ -68,8 +67,7 @@ class DataTargetRepository implements DataTargetInterface
         $this->targetClass = $targetClass;
         $this->repository = $repository;
         if ($persistenceManager === null) {
-            $persistenceManager = (GeneralUtility::makeInstance(ObjectManager::class))
-                ->get(PersistenceManagerInterface::class);
+            $persistenceManager = GeneralUtility::makeInstance(PersistenceManagerInterface::class);
         }
         if (null !== $persistenceManager) {
             $this->persistenceManager = $persistenceManager;

--- a/Classes/Persistence/Factory/DataTargetFactory.php
+++ b/Classes/Persistence/Factory/DataTargetFactory.php
@@ -89,6 +89,10 @@ class DataTargetFactory extends AbstractFactory implements FactoryInterface
             $target->setIdentifier($settings['identifier']);
         }
 
+        if ($target instanceof DataTargetRepository) {
+            $target->setTargetClass($objectClass);
+        }
+
         if ($target instanceof ConfigurableInterface && isset($settings['config'])) {
             /** @var ConfigurableInterface $target */
             $target->setConfiguration($settings['config']);

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
   ],
   "require": {
     "php": ">=8.2",
-    "dwenzel/t3extension-tools": "^3.1",
-    "typo3/cms-core": "^12.4",
+    "dwenzel/t3extension-tools": "^3 | ^4",
+    "typo3/cms-core": "^13.4",
     "ext-xmlreader": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
   ],
   "require": {
     "php": ">=8.2",
-    "dwenzel/t3extension-tools": "^3 | ^4",
     "typo3/cms-core": "^13.4",
     "ext-xmlreader": "*"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.5',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-12.4.99',
+            'typo3' => '12.4.0-13.4.99',
             'php' => '8.2.0-0.0.0'
         ],
         'conflicts' => [],


### PR DESCRIPTION
Little fix that remove the DataTargetRepository ObjectManager usage (this didn't exists in Typo3v12 anymore)

also use DI for the DataTargetRepository, to deal with the needed TargetClass, i'll at a setTargetClass and use it in the factory as a quickfix.